### PR TITLE
room_directory replace matrix.org by matrixrooms.info

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -28,7 +28,7 @@
     "default_federate": {{ default_federate }},
     "default_theme": "{{ default_theme }}",
     "room_directory": {
-        "servers": ["matrix.org"]
+        "servers": ["matrixrooms.info"]
     },
     "enable_presence_by_hs_url": {
         "https://matrix.org": false,


### PR DESCRIPTION
## Problem
Look for existing public room:
- By default local server room directory shows up
- then matrix.org is suggested which hides the federation

## Solution

- replace matrix.org by matrixrooms.info as `room_directory` 

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
